### PR TITLE
Clarify instructions a bit, improve disk usage

### DIFF
--- a/Dockerfile.gpuminer
+++ b/Dockerfile.gpuminer
@@ -44,7 +44,7 @@ RUN git clone -b ${BRANCH_NAME} https://github.com/trick77/bc-src /var/local/git
 RUN cd /var/local/git/bc-src/cuda-miner/src && make -f ../Makefile
 
 # ------------------------------------------------------------------------------
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+FROM nvidia/cuda:10.2-base-ubuntu18.04
 
 # Install required packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ In a nutshell:
 1. Install Debian 10 Buster as the host OS.
 1. Install the appropriate tools like ```apt-get install -y git wget curl ca-certificates```
 1. Install Docker from https://docs.docker.com/install/linux/docker-ce/debian/
-1. Install Nvidia's CUDA Drivers from https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&target_distro=Ubuntu&target_version=1804 
-    1. Use the **runfile** installer type and installation instructions.
+1. Install Nvidia's CUDA Drivers from http://us.download.nvidia.com/tesla/440.33.01/NVIDIA-Linux-x86_64-440.33.01.run 
+    1. It **must** be this version of the nvidia driver to function!
+    2. Do **not** install CUDA on the host machine unless you really know what you're doing!
 1. Install https://github.com/NVIDIA/nvidia-docker
 1. This might be a good time for a system reboot.
 1. ```git clone https://github.com/trick77/bcnode-gpu-docker bcnode-gpu-docker && cd $_```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In a nutshell:
 1. Install Docker from https://docs.docker.com/install/linux/docker-ce/debian/
 1. Install Nvidia's CUDA Drivers from http://us.download.nvidia.com/tesla/440.33.01/NVIDIA-Linux-x86_64-440.33.01.run 
     1. It **must** be this version of the nvidia driver to function!
-    2. Do **not** install CUDA on the host machine unless you really know what you're doing!
+    2. Do **not** run the full CUDA installer from nvidia on the host machine unless you really know what you're doing!
 1. Install https://github.com/NVIDIA/nvidia-docker
 1. This might be a good time for a system reboot.
 1. ```git clone https://github.com/trick77/bcnode-gpu-docker bcnode-gpu-docker && cd $_```

--- a/build-images.sh
+++ b/build-images.sh
@@ -14,6 +14,11 @@ echo -e "${GREEN}Rebuilding GPU miner sources... (this might take some time)${NC
 docker build --build-arg CACHEBUST=$(date +%s) -t local/gpuminer -f Dockerfile.gpuminer .
 echo
 
+echo -e "${GREEN}Removing intermediate build products..."
+yes | docker system prune --volumes
+docker rmi nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+echo
+
 echo -e "${GREEN}Pulling latest upstream image...${NC}"
 docker pull blockcollider/bcnode:latest
 echo

--- a/build-images.sh
+++ b/build-images.sh
@@ -14,7 +14,7 @@ echo -e "${GREEN}Rebuilding GPU miner sources... (this might take some time)${NC
 docker build --build-arg CACHEBUST=$(date +%s) -t local/gpuminer -f Dockerfile.gpuminer .
 echo
 
-echo -e "${GREEN}Removing intermediate build products..."
+echo -e "${GREEN}Removing intermediate build products...${NC}"
 yes | docker system prune --volumes
 docker rmi nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
 echo

--- a/build-images.sh
+++ b/build-images.sh
@@ -27,6 +27,10 @@ echo -e "${GREEN}Building new image...${NC}"
 docker build -t local/bcnode -f Dockerfile.bcnode .
 echo
 
+echo -e "${GREEN}Removing original bcnode image...${NC}"
+docker rmi blockcollider/bcnode:latest
+echo
+
 echo -e "${GREEN}Showing all locally available Docker images:${NC}"
 docker images
 

--- a/start.sh
+++ b/start.sh
@@ -16,11 +16,11 @@ export CUDA_HOME=/usr/local/cuda
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64
 export PATH=${PATH}:${CUDA_HOME}/bin
 echo -e "${GREEN}Let's see if and which version of Nvidia CUDA is available on the host:${NC}"
-nvcc --version
+nvidia-smi | head -3 | tail -1
 echo
 
 echo -e "${GREEN}Check the following output if Docker has access to one or more GPUs:${NC}"
-docker run --rm --gpus all nvidia/cuda:10.2-base nvidia-smi
+docker run --rm --gpus all nvidia/cuda:10.2-base-ubuntu18.04 nvidia-smi
 
 if [ -z "${BC_MINER_KEY}" ]; then
   echo


### PR DESCRIPTION
* clarify that user only needs to install nvidia drivers - specify driver version
* nvidia-docker will install part of cuda (nvidia-smi) but not nvcc, adapt to that
* consistently use nvidia/cuda:10.2-base-ubuntu18.04 to reduce disk usage

The resulting footprint is very manageable:
```
REPOSITORY             TAG                     IMAGE ID            CREATED             SIZE
local/bcnode           latest                  1d9223fa9279        13 minutes ago      888MB
local/gpuminer         latest                  689fb891ef19        14 minutes ago      255MB
blockcollider/bcnode   latest                  cdb91bd224ec        5 days ago          848MB
nvidia/cuda            10.2-base-ubuntu18.04   a6f6c250465c        4 months ago        108MB
```