### PR TITLE
Fix stales from GPU floating point math differences

### DIFF
--- a/Dockerfile.bcnode
+++ b/Dockerfile.bcnode
@@ -1,10 +1,14 @@
 FROM blockcollider/bcnode
 
-RUN apt-get update && apt-get install -y --no-install-recommends libfile-slurp-perl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libfile-slurp-perl patch && rm -rf /var/lib/apt/lists/*
 
 # Custom entrypoint
 COPY bcnode/docker-entrypoint.sh /
 
 COPY bcnode/monkey-patch /tmp
+
+COPY bcnode/officer.js.patch /tmp
+
+RUN patch ./lib/mining/officer.js /tmp/officer.js.patch
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/Dockerfile.gpuminer
+++ b/Dockerfile.gpuminer
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04 AS builder
+FROM nvidia/cuda:11.0-devel-ubuntu18.04 AS builder
 
 # Get basic packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/bcnode/officer.js.patch
+++ b/bcnode/officer.js.patch
@@ -1,0 +1,27 @@
+--- officer.js  2021-01-02 22:24:49.830000000 -0600
++++ officer.js.patched  2021-01-02 23:17:48.360000000 -0600
+@@ -26,7 +26,8 @@
+ const { calcTxFee } = require('bcjs/dist/transaction');
+ const { max, mean, merge, all, equals, values, min } = require('ramda');
+
+-const { prepareWork, prepareNewBlock, getUniqueBlocks } = require('./primitives');
++const { blake2bl } = require('../utils/crypto');
++const { distance, prepareWork, prepareNewBlock, getUniqueBlocks } = require('./primitives');
+ let numCPUs = max(1, Number(require('os').cpus().length) - 1);
+ const BC_MINER_WORKERS = process.env.BC_MINER_WORKERS !== undefined ? parseInt(process.env.BC_MINER_WORKERS) : numCPUs;
+ const { getLogger } = require('../logger');
+@@ -858,6 +859,15 @@
+           return;
+         }
+
++       var nonce_hash = blake2bl(response.getNonce());
++       var result_hash = blake2bl(minerRequest.getMinerKey() + minerRequest.getMerkleRoot() + nonce_hash + response.getTimestamp());
++       var result_distance = distance(minerRequest.getWork(), result_hash);
++       var dist_rpc = response.getDistance();
++       response.setDistance(result_distance.toString());
++
++       this._logger.info(`response raw distance: ${dist_rpc}`);
++       this._logger.info(`js recalc distance   : ${result_distance}`);
++
+         this._logger.info(`found work ${workId} from rust miner`);
+         this._logger.info('response from rust miner', response.toObject());


### PR DESCRIPTION
This patch will ensure that a solution received from an external miner will produce a valid block.

Occasionally there's a difference in the last digit, not many algorithms have 14 digits of accuracy in all floating point math implementations.